### PR TITLE
bug/search

### DIFF
--- a/app/src/main/java/kr/co/nexters/winepick/constant/Constant.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/constant/Constant.kt
@@ -15,6 +15,7 @@ object Constant {
 
     // RequestCode
     const val REQ_CODE_GO_TO_FILTER = 1
+    const val REQ_CODE_GO_TO_DETAIL = 2
 }
 
 /**

--- a/app/src/main/java/kr/co/nexters/winepick/data/model/local/Exceptions.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/data/model/local/Exceptions.kt
@@ -1,0 +1,8 @@
+package kr.co.nexters.winepick.data.model.local
+
+/**
+ * 에러 Exception 클래스를 모아놓은 파일
+ *
+ * @since v1.0.0 / 2021.03.31
+ */
+class LastPageException(message: String) : Throwable(message = message)

--- a/app/src/main/java/kr/co/nexters/winepick/data/model/remote/wine/PageInfo.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/data/model/remote/wine/PageInfo.kt
@@ -11,8 +11,8 @@ import kr.co.nexters.winepick.network.WinePickService
  * [WinePickService.getWines] 의 data.pageable 의 구조
  *
  * @param offset
- * @param pageNumber
- * @param pageSize
+ * @param page
+ * @param size
  * @param paged
  * @param sort
  * @param unpaged
@@ -24,13 +24,13 @@ data class PageInfo(
     @SerializedName("offset")
     val offset: Int? = null,
 
-    @SerialName("pageNumber")
-    @SerializedName("pageNumber")
-    val pageNumber: Int? = null,
+    @SerialName("page")
+    @SerializedName("page")
+    val page: Int? = null,
 
-    @SerialName("pageSize")
-    @SerializedName("pageSize")
-    val pageSize: Int? = null,
+    @SerialName("size")
+    @SerializedName("size")
+    val size: Int? = null,
 
     @SerialName("paged")
     @SerializedName("paged")

--- a/app/src/main/java/kr/co/nexters/winepick/data/model/remote/wine/WinesResult.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/data/model/remote/wine/WinesResult.kt
@@ -139,8 +139,8 @@ fun getWinesResponse(): WinePickResponse<WinesResult> = Json.decodeFromString(
             "empty": true
           },
           "offset": 0,
-          "pageNumber": 0,
-          "pageSize": 20,
+          "page": 0,
+          "size": 20,
           "paged": true,
           "unpaged": false
         },

--- a/app/src/main/java/kr/co/nexters/winepick/data/repository/WineRepository.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/data/repository/WineRepository.kt
@@ -42,20 +42,20 @@ class WineRepository(private val wineDataSource: WineDataSource, val sharedPrefs
 
     /** [WineDataSource] 를 통해, 와인 목록 [List] 을 가져온다. */
     suspend fun getWines(
-        pageSize: Int,
-        pageNumber: Int = 0,
+        size: Int,
+        page: Int = 0,
         sort: String = "",
     ) = withContext(Dispatchers.IO) {
-        return@withContext wineDataSource.getWines(pageSize, pageNumber, sort)
+        return@withContext wineDataSource.getWines(page, page, sort)
     }
 
     /** [WineDataSource] 를 통해, 키워드와 매칭 되는 와인 목록 [List] 을 가져온다. */
     suspend fun getWinesKeyword(
-        pageSize: Int,
-        pageNumber: Int = 0,
+        size: Int,
+        page: Int = 0,
         keyword: String = "",
     ) = withContext(Dispatchers.IO) {
-        return@withContext wineDataSource.getWinesKeyword(pageSize, pageNumber, keyword)
+        return@withContext wineDataSource.getWinesKeyword(size, page, keyword)
     }
 
     /** [WineDataSource] 를 통해, 특정 와인에 대한 정보 [WineResult] 를 가져온다. */
@@ -72,8 +72,8 @@ class WineRepository(private val wineDataSource: WineDataSource, val sharedPrefs
         start: Int? = null,
         end: Int? = null,
         keywords: List<String> = listOf(""),
-        pageSize: Int,
-        pageNumber: Int = 0,
+        size: Int,
+        page: Int = 0,
         sort: String? = null,
     ) = withContext(Dispatchers.IO) {
         return@withContext wineDataSource.getWinesFilter(
@@ -84,8 +84,8 @@ class WineRepository(private val wineDataSource: WineDataSource, val sharedPrefs
             start,
             end,
             keywords,
-            pageSize,
-            pageNumber,
+            size,
+            page,
             sort
         )
     }

--- a/app/src/main/java/kr/co/nexters/winepick/data/source/WineDataSource.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/data/source/WineDataSource.kt
@@ -21,14 +21,14 @@ class WineDataSource(private val winePickService: WinePickService) {
 
     /** [WinePickService.getWines] 요청에 대한 비즈니스 로직 */
     suspend fun getWines(
-        pageSize: Int,
-        pageNumber: Int = 0,
+        size: Int,
+        page: Int = 0,
         sort: String = "",
     ): WinesResult? = withContext(Dispatchers.IO) {
         if (isMock) {
             return@withContext getWinesResponse().result
         } else {
-            val response = winePickService.getWines(pageSize, pageNumber, sort).send()
+            val response = winePickService.getWines(size, page, sort).send()
 
             /** statusCode 별 처리 */
             when (response.code()) {
@@ -43,14 +43,14 @@ class WineDataSource(private val winePickService: WinePickService) {
 
     /** [WinePickService.getWines] 요청에 대한 비즈니스 로직 */
     suspend fun getWinesKeyword(
-        pageSize: Int,
-        pageNumber: Int = 0,
+        size: Int,
+        page: Int = 0,
         keyword: String
     ): WinesResult? = withContext(Dispatchers.IO) {
         if (isMock) {
             return@withContext getWinesResponse().result
         } else {
-            val response = winePickService.getWinesKeyword(pageSize, pageNumber, keyword).send()
+            val response = winePickService.getWinesKeyword(size, page, keyword).send()
 
             /** statusCode 별 처리 */
             when (response.code()) {
@@ -91,8 +91,8 @@ class WineDataSource(private val winePickService: WinePickService) {
      * @param start 도수 시작점
      * @param end 도수 끝
      * @param keywords 키워드
-     * @param pageSize 한번에 가져올 사이즈
-     * @param pageNumber 해당 페이지
+     * @param size 한번에 가져올 사이즈
+     * @param page 해당 페이지
      * @param sort id 기준으로 내림차순/오름차순 정렬 가능 유무
      *
      * */
@@ -104,8 +104,8 @@ class WineDataSource(private val winePickService: WinePickService) {
         start: Int? = null,
         end: Int? = null,
         keywords: List<String> = listOf(""),
-        pageSize: Int,
-        pageNumber: Int = 0,
+        size: Int,
+        page: Int = 0,
         sort: String? = null,
     ): WinesResult? = withContext(Dispatchers.IO) {
         if (isMock) {
@@ -120,8 +120,8 @@ class WineDataSource(private val winePickService: WinePickService) {
             start?.let { queryBuilder.append("start=${start}&") }
             end?.let { queryBuilder.append("end=${end}&") }
             keywords.forEach { keyword -> queryBuilder.append("keyword=${keyword}&") }
-            queryBuilder.append("pageSize=${pageSize}&")
-            queryBuilder.append("pageNumber=${pageNumber}&")
+            queryBuilder.append("size=${size}&")
+            queryBuilder.append("page=${page}&")
             sort?.let { queryBuilder.append("sort=${sort}") }
 
             val response =

--- a/app/src/main/java/kr/co/nexters/winepick/data/source/WineDataSource.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/data/source/WineDataSource.kt
@@ -2,6 +2,7 @@ package kr.co.nexters.winepick.data.source
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kr.co.nexters.winepick.data.model.local.LastPageException
 import kr.co.nexters.winepick.data.model.remote.wine.WineResult
 import kr.co.nexters.winepick.data.model.remote.wine.WinesResult
 import kr.co.nexters.winepick.data.model.remote.wine.getWineResponse
@@ -54,7 +55,7 @@ class WineDataSource(private val winePickService: WinePickService) {
 
             /** statusCode 별 처리 */
             when (response.code()) {
-
+                500 -> throw LastPageException("${response.code()} API 오류")
             }
 
             if (!response.isSuccessful) throw Throwable("${response.code()} API 오류")

--- a/app/src/main/java/kr/co/nexters/winepick/network/WinePickService.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/network/WinePickService.kt
@@ -19,16 +19,16 @@ interface WinePickService {
 
     @GET("v2/api/wine")
     fun getWines(
-        @Query("pageSize") pageSize: Int,       // 한번에 가져올 사이즈
-        @Query("pageNumber") pageNumber: Int?,  // 해당 페이지
-        @Query("sort") sort: String             // id 기준으로 내림차순/오름차순 정렬 가능 유무
+        @Query("size") size: Int,       // 한번에 가져올 사이즈
+        @Query("page") page: Int?,      // 해당 페이지
+        @Query("sort") sort: String     // id 기준으로 내림차순/오름차순 정렬 가능 유무
     ): Call<WinePickResponse<WinesResult>>
 
     @GET("v2/api/wine/keyword")
     fun getWinesKeyword(
-        @Query("pageSize") pageSize: Int,       // 한번에 가져올 사이즈
-        @Query("pageNumber") pageNumber: Int?,  // 해당 페이지
-        @Query("keyword") sort: String          // 키워드 정보
+        @Query("size") size: Int,       // 한번에 가져올 사이즈
+        @Query("page") page: Int?,      // 해당 페이지
+        @Query("keyword") sort: String  // 키워드 정보
     ): Call<WinePickResponse<WinesResult>>
 
     @GET("v2/api/wine/{wine_id}")

--- a/app/src/main/java/kr/co/nexters/winepick/ui/base/BaseActivity.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/ui/base/BaseActivity.kt
@@ -72,6 +72,7 @@ abstract class BaseActivity<B : ViewDataBinding>(
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         Timber.i("requestCode : $requestCode, resultCode : $resultCode, intent : $intent")
+        deferred.complete(ActivityResult(resultCode, data))
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/kr/co/nexters/winepick/ui/base/BaseViewModel.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/ui/base/BaseViewModel.kt
@@ -7,7 +7,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.disposables.Disposable
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 /**
  * BaseViewModel
@@ -20,6 +22,11 @@ open class BaseViewModel : ViewModel() {
     /** viewModel 에서 [LoadingAnimation] 를 control 하기 위한 LiveData */
     private val _loadingVisible = MutableLiveData(false)
     val loadingVisible: LiveData<Boolean> = _loadingVisible
+
+    /** viewModelScope 에서 Exception 이 발생할 시 처리하는 핸들러 */
+    val vmExceptionHandler = CoroutineExceptionHandler { coroutineContext, throwable ->
+        Timber.i("$coroutineContext $throwable")
+    }
 
     /** 생성자 개념으로 생각하면 편할듯 */
     init {
@@ -64,6 +71,6 @@ open class BaseViewModel : ViewModel() {
      * 필수가 아니므로 추상화는 하지 않는다.
      */
     open fun onResume() {
-        
+
     }
 }

--- a/app/src/main/java/kr/co/nexters/winepick/ui/detail/WineDetailViewModel.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/ui/detail/WineDetailViewModel.kt
@@ -155,6 +155,7 @@ class WineDetailViewModel(private val winePickRepository: WinePickRepository, pr
             WineValue("타닌",WinePickApplication.appContext!!.getString(R.string.tannin_detail),_wineResult.value!!.tannin!!,"많음","적음",false)
             )
 
+        hideLoading()
     }
     fun wineStore(store : String) {
         when(store) {

--- a/app/src/main/java/kr/co/nexters/winepick/ui/search/SearchActivity.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/ui/search/SearchActivity.kt
@@ -1,24 +1,20 @@
 package kr.co.nexters.winepick.ui.search
 
 import android.content.Intent
-import android.graphics.PorterDuff
 import android.os.Bundle
-import android.os.Handler
 import android.widget.Toast
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
-import com.kakao.sdk.auth.LoginClient
 import kotlinx.coroutines.launch
 import kr.co.nexters.winepick.BR
 import kr.co.nexters.winepick.R
+import kr.co.nexters.winepick.WinePickApplication
 import kr.co.nexters.winepick.data.constant.Constant
 import kr.co.nexters.winepick.databinding.ActivitySearchBinding
 import kr.co.nexters.winepick.di.AuthManager
 import kr.co.nexters.winepick.ui.base.ActivityResult
 import kr.co.nexters.winepick.ui.base.BaseActivity
-import kr.co.nexters.winepick.ui.component.ConfirmDialog
 import kr.co.nexters.winepick.ui.component.LikeDialog
-import kr.co.nexters.winepick.ui.splash.SplashActivity
+import kr.co.nexters.winepick.ui.detail.WineDetailActivity
 import kr.co.nexters.winepick.util.*
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -30,8 +26,8 @@ import timber.log.Timber
  * @since v1.0.0 / 2021.02.06
  */
 class SearchActivity : BaseActivity<ActivitySearchBinding>(R.layout.activity_search) {
-    override val viewModel : SearchViewModel by viewModel()
-    private val authManager : AuthManager by inject()
+    override val viewModel: SearchViewModel by viewModel()
+    private val authManager: AuthManager by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -61,16 +57,6 @@ class SearchActivity : BaseActivity<ActivitySearchBinding>(R.layout.activity_sea
     override fun onResume() {
         super.onResume()
         viewModel.onResume()
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-
-        if (requestCode == Constant.REQ_CODE_GO_TO_FILTER) {
-            deferred.complete(ActivityResult(resultCode, data))
-        } else {
-            super.onActivityResult(requestCode, resultCode, data)
-        }
     }
 
     fun subscribeUI() {
@@ -116,7 +102,7 @@ class SearchActivity : BaseActivity<ActivitySearchBinding>(R.layout.activity_sea
             }
         }
         viewModel.toastMessage.observe(this, Observer {
-            if(it) {
+            if (it) {
                 LikeDialog(
                     content = getString(R.string.like_add)
                 ).show(supportFragmentManager, "LikeDialog")
@@ -128,12 +114,23 @@ class SearchActivity : BaseActivity<ActivitySearchBinding>(R.layout.activity_sea
         })
 
         viewModel.cancelMessage.observe(this, Observer {
-            if(it) {
+            if (it) {
                 val customToast = Toast(this)
                 customToast.drawCancelToast(this)
                 binding.apply {
                     rvResults.adapter!!.notifyDataSetChanged()
                 }
+            }
+        })
+
+        viewModel.clickedWineResult.observe(this, {
+            uiScope.launch {
+                val intent = Intent(this@SearchActivity, WineDetailActivity::class.java)
+                    .apply { putExtra("wineData", it) }
+
+                startActivity(intent, Constant.REQ_CODE_GO_TO_DETAIL)
+
+                viewModel.updateClickPosition(it)
             }
         })
     }

--- a/app/src/main/java/kr/co/nexters/winepick/ui/search/SearchActivity.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/ui/search/SearchActivity.kt
@@ -94,7 +94,7 @@ class SearchActivity : BaseActivity<ActivitySearchBinding>(R.layout.activity_sea
 
                         if (needToUpdate) {
                             toast("검색 화면 목록 갱신 시작")
-                            viewModel.querySearchClick(pageNumber = 0)
+                            viewModel.querySearchClick(page = 0)
                         }
                     }
                 }

--- a/app/src/main/java/kr/co/nexters/winepick/ui/search/SearchRecommendAdapter.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/ui/search/SearchRecommendAdapter.kt
@@ -47,7 +47,7 @@ class SearchRecommendAdapter(
         return SearchRecommendViewHolder(binding).apply {
             itemView.setOnSingleClickListener {
                 val recommendValue = binding.searchRecommend!!.split("#").last()
-                vm.queryRecommendClick(recommendValue, pageNumber = 0)
+                vm.queryRecommendClick(recommendValue, page = 0)
             }
         }
     }

--- a/app/src/main/java/kr/co/nexters/winepick/ui/search/SearchRelativeAdapter.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/ui/search/SearchRelativeAdapter.kt
@@ -25,7 +25,7 @@ class SearchRelativeAdapter(val vm: SearchViewModel) :
 
         return SearchRelativeViewHolder(binding).apply {
             itemView.setOnSingleClickListener {
-                vm.querySearchClick(binding.searchRelative!!.htmlUnStyling(), pageNumber = 0)
+                vm.querySearchClick(binding.searchRelative!!.htmlUnStyling(), page = 0)
             }
         }
     }

--- a/app/src/main/java/kr/co/nexters/winepick/util/EndlessScrollListener.kt
+++ b/app/src/main/java/kr/co/nexters/winepick/util/EndlessScrollListener.kt
@@ -49,5 +49,10 @@ abstract class EndlessScrollListener(
         }
     }
 
+    fun reset(){
+        currentPage = 0
+        previousTotalItemCount = 0
+    }
+
     abstract fun onLoadMore(page: Int)
 }

--- a/app/src/test/java/kr/co/nexters/winepick/api/search/WineApiTest.kt
+++ b/app/src/test/java/kr/co/nexters/winepick/api/search/WineApiTest.kt
@@ -2,7 +2,6 @@ package kr.co.nexters.winepick.api.search
 
 import kotlinx.coroutines.runBlocking
 import kr.co.nexters.winepick.base.AndroidBaseTest
-import kr.co.nexters.winepick.data.model.remote.wine.WineResult
 import kr.co.nexters.winepick.data.source.WineDataSource
 import org.junit.Assert
 import org.junit.Test
@@ -67,7 +66,7 @@ class WineApiTest : AndroidBaseTest() {
         val resultTemp = wineDataSource.getWinesFilter(
             wineName = "쁘띠폴리",
             keywords = listOf("달콤한"),
-            pageSize = 1
+            size = 1
         )
 
         print("$resultTemp")


### PR DESCRIPTION
1. 검색 화면에서 상세 화면으로 이동하여 작업한 내용을 반영하지 못했던 내용 수정
  리스트의 변화를 줄이기 위해 단일 index 로 처리했으며,
  추후 상세에서 타 와인 컨텐츠로 넘어갈 수 있을 시 자체 검색을 다시 진행할 것

2. 요청 시 잘못된 쿼리 내용 수정 (pageNumber -> page / pageSize -> size)

3. 500 에러 대응 및 데이터 갱신 시 recyclerView, scrollListener 초기화하도록 설정

( \+ 추천 키워드 검색 시 검색창 입력 내용 앞에 #을 반드시 붙이도록 하는 것을 제안할 예정)